### PR TITLE
Update SRA.experiment.xsd with 2 library_strategy definitions

### DIFF
--- a/src/main/resources/uk/ac/ebi/ena/sra/schema/SRA.experiment.xsd
+++ b/src/main/resources/uk/ac/ebi/ena/sra/schema/SRA.experiment.xsd
@@ -92,7 +92,11 @@
           <xs:documentation> Random sequencing of a whole chromosome or other replicon isolated from a genome. </xs:documentation>
         </xs:annotation>
       </xs:enumeration>
-      <xs:enumeration value="RAD-Seq"/>
+      <xs:enumeration value="RAD-Seq">
+        <xs:annotation>
+          <xs:documentation> Restriction site associated DNA marker. </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration> 
       <xs:enumeration value="CLONE">
         <xs:annotation>
           <xs:documentation> Genomic clone based (hierarchical) sequencing. </xs:documentation>
@@ -202,7 +206,11 @@
           <xs:documentation>Enrichment of a targeted subset of loci.</xs:documentation>
         </xs:annotation>
       </xs:enumeration>
-      <xs:enumeration value="Tethered Chromatin Conformation Capture"/>
+      <xs:enumeration value="Tethered Chromatin Conformation Capture">
+        <xs:annotation>
+          <xs:documentation> Tethered Chromatin Conformation Capture. </xs:documentation>
+        </xs:annotation>
+      </xs:enumeration>
       <xs:enumeration value="NOMe-Seq">
         <xs:annotation>
           <xs:documentation>Nucleosome Occupancy and Methylome sequencing.</xs:documentation>


### PR DESCRIPTION
Update SRA.experiment.xsd with 2 library_strategy definitions, for RAD-Seq and for Tethered Chromatin Conformation Capture. There previously was no definition for either.
Please do make sure that this change is propagated elsewhere too.